### PR TITLE
Fix google-go-lang build error and improve robustness

### DIFF
--- a/.github/workflows/google-go-lang.yml
+++ b/.github/workflows/google-go-lang.yml
@@ -17,4 +17,4 @@ jobs:
     secrets: inherit
     with:
       DEPLOY: ${{ inputs.do_deploy }}
-      NAME: "Build google-go-lang"
+      NAME: "google-go-lang"

--- a/.github/workflows/sbopkg_template.yml
+++ b/.github/workflows/sbopkg_template.yml
@@ -94,7 +94,7 @@ jobs:
           if [ -n "${{ inputs.GIT }}" ]; then
             export GIT_URL="${{ inputs.GIT }}"
           fi
-          ./sbo-build.sh ${{ inputs.NAME }} <<< p
+          ./sbo-build.sh "${{ inputs.NAME }}" <<< p
       
       # We upload the built package so the next job can pick it up
       - name: Upload built package as intermediate artifact
@@ -136,9 +136,9 @@ jobs:
 
       - name: Process Package and Repository Files
         run: |
-          rm -rf /tmp/site-root/builds/${{ inputs.NAME }}
-          mkdir -p /tmp/site-root/builds/${{ inputs.NAME }}
-          find /tmp -name "${{ inputs.NAME }}-*.t?z" -exec cp {} /tmp/site-root/builds/${{ inputs.NAME }}/ \;
+          rm -rf /tmp/site-root/builds/"${{ inputs.NAME }}"
+          mkdir -p /tmp/site-root/builds/"${{ inputs.NAME }}"
+          find /tmp -name "${{ inputs.NAME }}-*.t?z" -exec cp {} /tmp/site-root/builds/"${{ inputs.NAME }}"/ \;
           
           slackpkg update gpg || true
           slackpkg update || true

--- a/sbo-build.sh
+++ b/sbo-build.sh
@@ -49,6 +49,8 @@ step_1_locate_workspace() {
         WORKSPACE_SRC="/__w/Slackware_Packages/Slackware_Packages/SlackBuilds/${PACKAGE}"
     elif [ -d "/root/Slackware_Packages/SlackBuilds/${PACKAGE}" ]; then
         WORKSPACE_SRC="/root/Slackware_Packages/SlackBuilds/${PACKAGE}"
+    elif [ -d "./SlackBuilds/${PACKAGE}" ]; then
+        WORKSPACE_SRC="./SlackBuilds/${PACKAGE}"
     fi
 
     DEST_DIR="${SBO_ROOT}/SBo/15.0/development/${PACKAGE}"
@@ -62,10 +64,10 @@ step_1_locate_workspace() {
         LOCAL_MODE=true
 
         # Your intentional tar/gpg logic
-        tar -czf ${PACKAGE}.tar.gz -C "$(dirname "${DEST_DIR}")" "${PACKAGE}"
-        gpg --armor --detach-sign ${PACKAGE}.tar.gz
-        mv ${PACKAGE}.tar.gz "${SBO_ROOT}/SBo/15.0/development/"
-        mv ${PACKAGE}.tar.gz.asc "${SBO_ROOT}/SBo/15.0/development/"
+        tar -czf "${PACKAGE}.tar.gz" -C "$(dirname "${DEST_DIR}")" "${PACKAGE}"
+        gpg --armor --detach-sign "${PACKAGE}.tar.gz"
+        mv "${PACKAGE}.tar.gz" "${SBO_ROOT}/SBo/15.0/development/"
+        mv "${PACKAGE}.tar.gz.asc" "${SBO_ROOT}/SBo/15.0/development/"
     else
         info "Workspace source not found. Falling back to sbopkg..."
         command -v sbopkg &>/dev/null || die "sbopkg not found and no local workspace exists."


### PR DESCRIPTION
This PR fixes a failure in the `google-go-lang` GitHub Action where the package name was incorrectly identified as "Build". 

Key changes:
1.  **Workflow Correction**: Updated `.github/workflows/google-go-lang.yml` to set `NAME: "google-go-lang"` instead of `"Build google-go-lang"`.
2.  **Robustness Improvements**:
    *   Added double-quoting to `${PACKAGE}` and other relevant variables in `sbo-build.sh`.
    *   Added double-quoting to `${{ inputs.NAME }}` within shell `run` blocks in `.github/workflows/sbopkg_template.yml` to prevent word splitting if a name with spaces is used.
    *   Ensured that literal quotes are NOT used in non-shell YAML fields (like `path` and `FOLDER`) to avoid breaking GitHub Actions path resolution.
3.  **Local Development**: Updated `sbo-build.sh` to also search for SlackBuilds in `./SlackBuilds/` relative to the current directory.
4.  **Cleanup**: Removed a temporary `test package.tar.gz` file created during verification.

---
*PR created automatically by Jules for task [10146745163543816572](https://jules.google.com/task/10146745163543816572) started by @bobbintb*